### PR TITLE
1 cycles

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -2,13 +2,16 @@
 #include "operations.h"
 #include "Disassembler.h"
 
-byte getParity(byte input){
+/*
+   returns 1 if parity and 2 if parity is odd
+*/
+bool getParity(byte input){
     byte ones = 0;
     for(int i = 0; i < 8 ; i++){
         ones += ((input >> i ) & 1);
     }
 
-    return ones & 1;
+    return ones & 1 == 0 ;
 }
 
 
@@ -25,7 +28,7 @@ void cpu_setFlags(struct ConditionCodes* cc,  byte* reg){
 
 
 
-uint16_t cpu_add(byte *src, byte *dst, CPUState* p_state){ 
+uint16_t cpu_add(byte *src, byte *dst){ 
 
     uint16_t res = (uint16_t) *src + (uint16_t) *dst;
     *dst = (byte) res;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -66,28 +66,29 @@ byte cpu_fetch(CPUState* p_state){
 
 
 int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
+    int cycles = 0;
     switch(opcode){
         case 0x00:
         // NOP
         break;
     case 0x01:
-        op_LXI(p_state, opcode);
+        cycles = op_LXI(p_state, opcode);
         p_state -> pc += 2;
         break;
     case 0x02:
-        op_STAX(p_state, opcode);
+        cycles = op_STAX(p_state, opcode);
         break;
     case 0x03:
-        op_INX(p_state, opcode);
+        cycles = op_INX(p_state, opcode);
         break;
     case 0x04:
         op_unimplemented(opcode);
         break;
     case 0x05:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x06:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x07:
@@ -97,10 +98,10 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         // unsupported
         break;
     case 0x09:
-        op_DAD(p_state, opcode);
+        cycles = op_DAD(p_state, opcode);
         break;
     case 0x0a:
-        op_LDAX(p_state, opcode);
+        cycles = op_LDAX(p_state, opcode);
         break;
     case 0x0b:
         op_unimplemented(opcode);
@@ -109,36 +110,36 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         op_unimplemented(opcode);
         break;
     case 0x0d:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x0e:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x0f:
-        op_RAC(p_state, opcode);
+        cycles = op_RAC(p_state, opcode);
         break;
     case 0x10:
         // unsupported
         break;
     case 0x11:
-        op_LXI(p_state, opcode);
+        cycles = op_LXI(p_state, opcode);
         p_state -> pc += 2;
         break;
     case 0x12:
-        op_STAX(p_state, opcode);
+        cycles = op_STAX(p_state, opcode);
         break;
     case 0x13:
-        op_INX(p_state, opcode);
+        cycles = op_INX(p_state, opcode);
         break;
     case 0x14:
         op_unimplemented(opcode);
         break;
     case 0x15:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x16:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x17:
@@ -148,10 +149,10 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         // unsupported 
         break;
     case 0x19:
-        op_DAD(p_state, opcode);
+        cycles = op_DAD(p_state, opcode);
         break;
     case 0x1a:
-        op_LDAX(p_state, opcode);
+        cycles = op_LDAX(p_state, opcode);
         break;
     case 0x1b:
         op_unimplemented(opcode);
@@ -160,10 +161,10 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         op_unimplemented(opcode);
         break;
     case 0x1d:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x1e:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x1f:
@@ -173,7 +174,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         op_unimplemented(opcode);
         break;
     case 0x21:
-        op_LXI(p_state, opcode);
+        cycles = op_LXI(p_state, opcode);
         p_state -> pc += 2;
         break;
     case 0x22:
@@ -181,16 +182,16 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         p_state -> pc += 2;
         break;
     case 0x23:
-        op_INX(p_state, opcode);
+        cycles = op_INX(p_state, opcode);
         break;
     case 0x24:
         op_unimplemented(opcode);
         break;
     case 0x25:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x26:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x27:
@@ -200,7 +201,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         // unsupported
         break;
     case 0x29:
-        op_DAD(p_state, opcode);
+        cycles = op_DAD(p_state, opcode);
         break;
     case 0x2a:
         p_state -> pc += 2;
@@ -212,10 +213,10 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         op_unimplemented(opcode);
         break;
     case 0x2d:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x2e:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x2f:
@@ -225,24 +226,24 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         op_unimplemented(opcode);
         break;
     case 0x31:
-        op_LXI(p_state, opcode);
+        cycles = op_LXI(p_state, opcode);
         p_state -> pc += 2;
         break;
     case 0x32:
-        op_STA(p_state, opcode);
+        cycles = op_STA(p_state, opcode);
         p_state -> pc += 2;
         break;
     case 0x33:
-        op_INX(p_state, opcode);
+        cycles = op_INX(p_state, opcode);
         break;
     case 0x34:
         op_unimplemented(opcode);
         break;
     case 0x35:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x36:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x37:
@@ -252,10 +253,10 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         // unsupported
         break;
     case 0x39:
-        op_DAD(p_state, opcode);
+        cycles = op_DAD(p_state, opcode);
         break;
     case 0x3a:
-        op_LDA(p_state, opcode);
+        cycles = op_LDA(p_state, opcode);
         p_state -> pc += 2;
         break;
     case 0x3b:
@@ -265,10 +266,10 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         op_unimplemented(opcode);
         break;
     case 0x3d:
-        op_DCR(p_state, opcode);
+        cycles = op_DCR(p_state, opcode);
         break;
     case 0x3e:
-        op_MVI(p_state, opcode);
+        cycles = op_MVI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0x3f:
@@ -328,7 +329,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0x73:
     case 0x74:
     case 0x75:
-        op_MOV(p_state, opcode);
+        cycles = op_MOV(p_state, opcode);
         break;
     case 0x76:
         op_unimplemented(opcode);
@@ -342,7 +343,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0x7d:
     case 0x7e:
     case 0x7f:
-        op_MOV(p_state, opcode);
+        cycles = op_MOV(p_state, opcode);
         break;
     case 0x80:
     case 0x81:
@@ -352,7 +353,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0x85:
     case 0x86:
     case 0x87:
-        op_ADD(p_state, opcode);
+        cycles = op_ADD(p_state, opcode);
         break;
     case 0x88:
     case 0x89:
@@ -362,7 +363,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0x8d:
     case 0x8e:
     case 0x8f:
-        op_ADC(p_state, opcode);
+        cycles = op_ADC(p_state, opcode);
         break;
     case 0x90:
         break;
@@ -404,7 +405,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0xa5:
     case 0xa6:
     case 0xa7:
-        op_ANA(p_state, opcode);
+        cycles = op_ANA(p_state, opcode);
         break;
     case 0xa8:
     case 0xa9:
@@ -414,7 +415,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0xad:
     case 0xae:
     case 0xaf:
-        op_XRA(p_state, opcode);
+        cycles = op_XRA(p_state, opcode);
         break;
     case 0xb0:
         break;
@@ -451,22 +452,22 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0xc0:
         break;
     case 0xc1:
-        op_POP(p_state, opcode);
+        cycles = op_POP(p_state, opcode);
         break;
     case 0xc2:
-        op_JNZ(p_state, opcode);
+        cycles = op_JNZ(p_state, opcode);
         break;
     case 0xc3:
-        op_JMP(p_state, opcode);
+        cycles = op_JMP(p_state, opcode);
         break;
     case 0xc4:
         p_state -> pc += 2;
         break;
     case 0xc5:
-        op_PUSH(p_state, opcode);
+        cycles = op_PUSH(p_state, opcode);
         break;
     case 0xc6:
-        op_ADI(p_state, opcode);
+        cycles = op_ADI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0xc7:
@@ -474,7 +475,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0xc8:
         break;
     case 0xc9:
-        op_RET(p_state, opcode);
+        cycles = op_RET(p_state, opcode);
         break;
     case 0xca:
         p_state -> pc += 2;
@@ -486,7 +487,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         p_state -> pc += 2;
         break;
     case 0xcd:
-        op_CALL(p_state, opcode);
+        cycles = op_CALL(p_state, opcode);
         break;
     case 0xce:
         
@@ -497,20 +498,20 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0xd0:
         break;
     case 0xd1:
-        op_POP(p_state, opcode);
+        cycles = op_POP(p_state, opcode);
         break;
     case 0xd2:
         p_state -> pc += 2;
         break;
     case 0xd3:
-        op_OUT(p_state, devices);
+        cycles = op_OUT(p_state, devices);
         p_state -> pc += 1;
         break;
     case 0xd4:
         p_state -> pc += 2;
         break;
     case 0xd5:
-        op_PUSH(p_state, opcode);
+        cycles = op_PUSH(p_state, opcode);
         break;
     case 0xd6:
         
@@ -527,7 +528,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         p_state -> pc += 2;
         break;
     case 0xdb:
-        op_IN(p_state, devices);
+        cycles = op_IN(p_state, devices);
         p_state -> pc += 1;
         break;
     case 0xdc:
@@ -545,7 +546,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0xe0:
         break;
     case 0xe1:
-        op_POP(p_state, opcode);
+        cycles = op_POP(p_state, opcode);
         break;
     case 0xe2:
         p_state -> pc += 2;
@@ -556,10 +557,10 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         p_state -> pc += 2;
         break;
     case 0xe5:
-        op_PUSH(p_state, opcode);
+        cycles = op_PUSH(p_state, opcode);
         break;
     case 0xe6:
-        op_ANI(p_state, opcode);
+        cycles = op_ANI(p_state, opcode);
         p_state -> pc += 1;
         break;
     case 0xe7:
@@ -572,7 +573,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         p_state -> pc += 2;
         break;
     case 0xeb:
-        op_XCHG(p_state, opcode);
+        cycles = op_XCHG(p_state, opcode);
         break;
     case 0xec:
         p_state -> pc += 2;
@@ -589,20 +590,20 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
     case 0xf0:
         break;
     case 0xf1:
-        op_POP(p_state, opcode);
+        cycles = op_POP(p_state, opcode);
         break;
     case 0xf2:
         p_state -> pc += 2;
         break;
     case 0xf3:
         // disable interrupts
-        op_setI(p_state, 0);
+        cycles = op_setI(p_state, 0);
         break;
     case 0xf4:
         p_state -> pc += 2;
         break;
     case 0xf5:
-        op_PUSH(p_state, opcode);
+        cycles = op_PUSH(p_state, opcode);
         break;
     case 0xf6:
         
@@ -619,7 +620,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         break;
     case 0xfb:
         // Enable Interrupts
-        op_setI(p_state, 1);
+        cycles = op_setI(p_state, 1);
         break;
     case 0xfc:
         p_state -> pc += 2;
@@ -634,7 +635,7 @@ int cpu_execute(CPUState* p_state, byte opcode, Device* devices){
         break;
     }
 
-    return 0;
+    return cycles;
 
 }
 

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -35,11 +35,11 @@ typedef struct CPUState {
 
 
 
-byte getParity(byte input);
+bool getParity(byte input);
 
 void cpu_setFlags(struct ConditionCodes* cc,  byte* reg);
 
-uint16_t cpu_add(byte *src, byte *dst, CPUState* p_state);
+uint16_t cpu_add(byte *src, byte *dst);
 
 bool cpu_checkMemOp(byte opcode);
 

--- a/src/operations.c
+++ b/src/operations.c
@@ -557,15 +557,21 @@ int op_CALL(CPUState* p_state, byte opcode){
 
 /* ****************************  RETURN FROM SUBROUTINE INSTRUCTIONS *************************** */
 
+/*
+    Return
+
+    A return operation is unconditionally performed. Thus, execution proceeds with the instruction immediately following the last call instruction.
+
+    Condition bits affected: None
+*/
 int op_RET(CPUState* p_state, byte opcode){
     uint16_t addr = u8_to_u16(p_state -> memory[p_state -> sp  + 1], p_state -> memory[p_state -> sp]);
 
-    printf("Returning to %04x\n", addr);
     p_state -> sp += 2;
 
     p_state -> pc = addr;
 
-    return 0;
+    return CYCLES(10);
 }
 
 
@@ -576,10 +582,21 @@ int op_RET(CPUState* p_state, byte opcode){
 
 /* ****************************  INTERRUPT ENABLE/DISABLE INSTRUCTIONS *************************** */
 
+/*
+    Wrapper around EI and DI, where toggle is used control flow
+
+    toggle 1 (EI):
+    This instruction sets the INTE flip-flop, enabling the CPU to recognize and respond to interrupts
+
+    toggle 0 (DI):
+    This instruction resets the INTE flip-flop, causing the CPU to ignore all interrupts
+
+    Condition bits affected: None
+*/
 int op_setI(CPUState* p_state, byte toggle){
     p_state -> int_enable = toggle;
 
-    return 0;
+    return CYCLES(4);
 }
 
 
@@ -594,19 +611,36 @@ int op_setI(CPUState* p_state, byte toggle){
 
 /* ****************************  I/O INSTRUCTIONS *************************** */
 
+/*
+    Output
+
+    The contents of the accumulator are sent to output device number exp
+
+    exp : mem[PC]
+
+    Condition bits affected: None
+*/
 int op_OUT(CPUState* p_state, Device* devices){
     byte device_id = p_state -> memory[p_state -> pc];
     devices_write(device_id, p_state -> reg_a, devices);
 
-    return 0;
+    return CYCLES(10);
 }
 
+/*
+    Input
 
+    An eight-bit data byte is read from input device number exp and replaces the contents of the accumulator.
+
+    exp: mem[PC]
+
+    Condition bits affected: None
+*/
 int op_IN(CPUState* p_state, Device* devices){
     byte device_id = p_state -> memory[p_state -> pc];
     devices_read(device_id, &p_state -> reg_a, devices);
 
-    return 0;
+    return CYCLES(10);
 }
 
 

--- a/src/operations.c
+++ b/src/operations.c
@@ -227,7 +227,7 @@ int op_XCHG(CPUState* p_state, byte opcode){
     p_state -> reg_e = p_state -> reg_l;
     p_state -> reg_l = tmp; 
 
-    return 0;
+    return CYCLES(4);
 }
 
 
@@ -240,7 +240,7 @@ int op_INX(CPUState* p_state, byte opcode){
 
 
     deleteRegPair(rp);
-    return 0;
+    return CYCLES(5);
 }
 
 
@@ -260,20 +260,17 @@ int op_PUSH(CPUState* p_state, byte opcode){
                      p_state -> cc.flag_s << 7;
 
         p_state -> memory[p_state -> sp - 2] = flags;
-        printf("pushed: %04x onto stack\n", u8_to_u16(p_state -> memory [p_state -> sp - 1],p_state -> memory[p_state -> sp - 2]));
-
     }
     else {
         RegisterPair* rp = extractRegPair(p_state, opcode);
         p_state -> memory[p_state -> sp - 2] = *rp->low;
         p_state -> memory[p_state -> sp - 1] = *rp -> high;
         deleteRegPair(rp);
-        printf("pushed: %04x onto stack\n", u8_to_u16(p_state -> memory [p_state -> sp - 1],p_state -> memory[p_state -> sp - 2]));
     }
 
     p_state -> sp -= 2;
 
-    return 0;
+    return CYCLES(11);
 }
 
 
@@ -282,7 +279,6 @@ int op_POP(CPUState* p_state, byte opcode){
         // handle PSW 
         byte flags = p_state -> memory[p_state -> sp];
         p_state -> reg_a = p_state -> memory[p_state -> sp + 1];
-        printf("popped: %04x off of stack\n", u8_to_u16(p_state -> memory [p_state -> sp + 1],p_state -> memory[p_state -> sp]));
 
         p_state -> cc.flag_ac = flags >> 4 & 1;
         p_state -> cc.flag_cy = flags & 1;
@@ -294,13 +290,11 @@ int op_POP(CPUState* p_state, byte opcode){
         RegisterPair* rp = extractRegPair(p_state, opcode);
         *rp -> low = p_state -> memory[p_state -> sp];
         *rp -> high = p_state -> memory[p_state -> sp + 1];
-
-        printf("popped: %04x off of stack\n", u8_to_u16(p_state -> memory [p_state -> sp + 1],p_state -> memory[p_state -> sp]));
         deleteRegPair(rp);
     }
 
     p_state -> sp += 2;
-    return 0;
+    return CYCLES(10);
 }
 
 

--- a/src/operations.c
+++ b/src/operations.c
@@ -371,11 +371,13 @@ int op_CPI(CPUState* p_state, byte opcode){
     cpu_setFlags(&p_state -> cc, &res);
 
 
-    return 0;
+    return CYCLES(7);
 }
 
 
-
+/*
+    A bitwise AND operation is perfromed between the Accumulator and 1 byte of Immediate data
+*/
 int op_ANI(CPUState* p_state, byte opcode){
 
     p_state -> reg_a &= p_state -> memory[p_state -> pc];
@@ -384,10 +386,14 @@ int op_ANI(CPUState* p_state, byte opcode){
 
     cpu_setFlags(&p_state->cc, &p_state->reg_a);
 
-    return 0;
+    return CYCLES(7);
 }
 
+/*
+    Loads 2 bytes of Immediate data into the register pair specefied.
 
+    Condition bits affected: None
+*/
 int op_LXI(CPUState* p_state, byte opcode){
     RegisterPair* rp = extractRegPair(p_state, opcode);
     if(!rp -> sp){
@@ -399,17 +405,8 @@ int op_LXI(CPUState* p_state, byte opcode){
     }
     
     deleteRegPair(rp);
-    return 0; 
+    return CYCLES(10); 
 }
-
-
-
-
-
-
-
-
-
 
 
 


### PR DESCRIPTION
Every instruction now returns the number of CPU cycles needed. This is then passed up to the emulator, which will be used to get accurate timing.