### PR TITLE
2 timing

### DIFF
--- a/src/8080-Emulator.c
+++ b/src/8080-Emulator.c
@@ -60,10 +60,22 @@ int emulator_start(Emulator8080* emu){
         // check for interrupt
         elapsed_interrupt_usec = (now.tv_sec - emu -> cpu -> last_interrupt -> tv_sec ) * 1000000LL +
                                  (now.tv_usec - emu -> cpu -> last_interrupt -> tv_usec);
-        if(elapsed_interrupt_usec >= 16666){
+        if(elapsed_interrupt_usec >= 8333){
             // trigger interrupt
             emu -> cpu -> last_interrupt -> tv_sec = now.tv_sec;
             emu -> cpu -> last_interrupt -> tv_usec = now.tv_usec;
+
+            switch(emu -> cpu -> int_type){
+                case HALF_SCREEN:
+                    printf("Half Screen\n");
+                    emu -> cpu -> int_type = VBLANK;
+                    break;
+                case VBLANK:
+                    printf("VBLANK\n");
+                    emu -> cpu -> int_type = HALF_SCREEN;
+                    break;
+            }
+
             printf("interrupt triggered every %lli microseconds\n", elapsed_interrupt_usec);
             
         }

--- a/src/8080-Emulator.c
+++ b/src/8080-Emulator.c
@@ -67,16 +67,18 @@ int emulator_start(Emulator8080* emu){
 
             switch(emu -> cpu -> int_type){
                 case HALF_SCREEN:
-                    printf("Half Screen\n");
+                    // ISR #1
+
+
                     emu -> cpu -> int_type = VBLANK;
                     break;
                 case VBLANK:
-                    printf("VBLANK\n");
+                    // ISR #2
+
+
                     emu -> cpu -> int_type = HALF_SCREEN;
                     break;
             }
-
-            printf("interrupt triggered every %lli microseconds\n", elapsed_interrupt_usec);
             
         }
         

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -54,7 +54,9 @@ uint16_t cpu_add(byte *src, byte *dst){
 CPUState* cpu_init(void){
     CPUState* p_state = calloc(1, sizeof(CPUState));
     p_state -> tm = calloc(1, sizeof(struct timeval));
+    p_state -> last_interrupt = calloc(1, sizeof(struct timeval));
     gettimeofday(p_state -> tm, NULL);
+    gettimeofday(p_state -> last_interrupt, NULL);
     p_state -> memory = memory_init();
 
     return p_state;
@@ -64,6 +66,7 @@ CPUState* cpu_init(void){
 int cpu_cleanup(CPUState* p_state){
     memory_cleanup(p_state -> memory);
     free(p_state -> tm);
+    free(p_state -> last_interrupt);
     free(p_state);
 
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -59,6 +59,7 @@ CPUState* cpu_init(void){
     gettimeofday(p_state -> last_interrupt, NULL);
     p_state -> memory = memory_init();
 
+    p_state -> int_type = HALF_SCREEN;
     return p_state;
 
 }

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -11,6 +11,8 @@
 
 #define CYCLES(x) (x)
 
+typedef enum int_type{HALF_SCREEN, VBLANK} interrupt_type;
+
 struct ConditionCodes{
     byte    flag_z:1;
     byte    flag_s:1;
@@ -34,6 +36,7 @@ typedef struct CPUState {
     struct      ConditionCodes cc;
     struct  timeval *tm;
     struct  timeval *last_interrupt;
+    interrupt_type int_type;
     byte     int_enable;
 } CPUState;
 

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -33,6 +33,7 @@ typedef struct CPUState {
     Memory  memory;
     struct      ConditionCodes cc;
     struct  timeval *tm;
+    struct  timeval *last_interrupt;
     byte     int_enable;
 } CPUState;
 


### PR DESCRIPTION
The screen interrupts are now called at the correct time, with a microsecond resolution.

closes #2 